### PR TITLE
Update API availability and last updated date handling

### DIFF
--- a/pddikti/settings.py
+++ b/pddikti/settings.py
@@ -28,8 +28,9 @@ RIDWAANHALL_KEY=config('RIDWAANHALL_KEY')
 RIDWAANHALL_HASH_KEY=config('RIDWAANHALL_HASH_KEY')
 
 # API Status Control
-API_AVAILABILITY = config('API_AVAILABILITY', default=False, cast=bool) # false is limited access. true is full access
-API_VERSION = config('API_VERSION', default='3.0.3', cast=str)  # Default API version
+API_AVAILABILITY = config('API_AVAILABILITY', default=True, cast=bool) # false is limited access. true is full access
+API_VERSION = config('API_VERSION', default='3.0.4', cast=str)  # Default API version
+LAST_UPDATE = config('LAST_UPDATE', default='2025-08-22T15:04:00+07:00', cast=str)
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/

--- a/pddikti_api/views.py
+++ b/pddikti_api/views.py
@@ -187,7 +187,7 @@ class APIOverview(BaseAPIView):
                 "Provides structured access to data from Pangkalan Data Pendidikan Tinggi (PDDikti), "
                 "Indonesia’s Higher Education Database"
             ),
-            "last_updated": "2025-07-26T18:48:00+07:00",
+            "last_updated": settings.LAST_UPDATE,
             "author": "ridwaanhall"
         }
         resources = {


### PR DESCRIPTION
Replace the hardcoded last updated date with a dynamic setting from the configuration. Modify the API availability default to true and increment the API version to 3.0.4 to enhance service reliability.

Fixes #8